### PR TITLE
Add non-normative note to mention schemes accepted by Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ As seen above, the *rel="facilitated-payment"* attribute indicates that this is 
   - Example
     - ```<link rel=”facilitated-payment” href=”paypal://paypal.com?payee-address=175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W&currency=USD&amount=20.3&payee-name=Walmart”>```
 
-> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. If you're interested in adding support for these schemes to another browser, or guiding Chromium to connect other schemes to another payment provider (e.g. via an extension API), please reach out to explainer owners by email for connections to document and/or standardize this protocol.
+> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. If you're interested in adding support for these schemes to another browser, or guiding Chromium to connect other schemes to another payment client (e.g. via an extension API), please reach out to explainer owners by email for connections to document and/or standardize this protocol.
 
 ## Privacy considerations
 A malicious payment client could use the existence of payment links to track the user. This is an existing concern with e.g., extension based apps (which often ask for permission to view all webpages the user visits), but should be considered for this proposal too.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ As seen above, the *rel="facilitated-payment"* attribute indicates that this is 
   - Example
     - ```<link rel=”facilitated-payment” href=”paypal://paypal.com?payee-address=175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W&currency=USD&amount=20.3&payee-name=Walmart”>```
 
+> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. Although this protocol is not standardized, please reach out for conversations to document or standardize this protocol (e.g., via an extension API).
+
 ## Privacy considerations
 A malicious payment client could use the existence of payment links to track the user. This is an existing concern with e.g., extension based apps (which often ask for permission to view all webpages the user visits), but should be considered for this proposal too.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ As seen above, the *rel="facilitated-payment"* attribute indicates that this is 
   - Example
     - ```<link rel=”facilitated-payment” href=”paypal://paypal.com?payee-address=175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W&currency=USD&amount=20.3&payee-name=Walmart”>```
 
-> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. Although this protocol is not standardized, please reach out for conversations to document or standardize this protocol (e.g., via an extension API).
+> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. If you're interested in adding support for these schemes to another browser, or guiding Chromium to connect other schemes to another payment provider (e.g. via an extension API), please reach out to explainer owners by email for connections to document and/or standardize this protocolPay. If you're interested in adding support for these schemes to another browser, or guiding Chromium to connect other schemes to another payment provider (e.g. via an extension API), please reach out by email for connections to document and/or standardize this protocol.
 
 ## Privacy considerations
 A malicious payment client could use the existence of payment links to track the user. This is an existing concern with e.g., extension based apps (which often ask for permission to view all webpages the user visits), but should be considered for this proposal too.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ As seen above, the *rel="facilitated-payment"* attribute indicates that this is 
   - Example
     - ```<link rel=”facilitated-payment” href=”paypal://paypal.com?payee-address=175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W&currency=USD&amount=20.3&payee-name=Walmart”>```
 
-> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. If you're interested in adding support for these schemes to another browser, or guiding Chromium to connect other schemes to another payment provider (e.g. via an extension API), please reach out to explainer owners by email for connections to document and/or standardize this protocolPay. If you're interested in adding support for these schemes to another browser, or guiding Chromium to connect other schemes to another payment provider (e.g. via an extension API), please reach out by email for connections to document and/or standardize this protocol.
+> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. If you're interested in adding support for these schemes to another browser, or guiding Chromium to connect other schemes to another payment provider (e.g. via an extension API), please reach out to explainer owners by email for connections to document and/or standardize this protocol.
 
 ## Privacy considerations
 A malicious payment client could use the existence of payment links to track the user. This is an existing concern with e.g., extension based apps (which often ask for permission to view all webpages the user visits), but should be considered for this proposal too.

--- a/index.bs
+++ b/index.bs
@@ -65,7 +65,7 @@ The URL [=url/scheme=] of the <{link/href}> attribute indicates supported paymen
   <p><code class="html">&lt;link rel="facilitated-payment" href="paypal://paypal.com?payee-address=175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W&amp;currency=USD&amp;amount=20.3&amp;payee-name=Walmart"&gt;</code></p>
 </div>
 
-> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. Although this protocol is not standardized, please reach out for conversations to document or standardize this protocol (e.g., via an extension API).
+> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. If you're interested in adding support for these schemes to another browser, or guiding Chromium to connect other schemes to another payment provider (e.g. via an extension API), please reach out to explainer owners by email for connections to document and/or standardize this protocol.
 
 The appropriate times to <a spec="HTML">fetch and process the linked resource</a> for such a link are:
 

--- a/index.bs
+++ b/index.bs
@@ -65,6 +65,8 @@ The URL [=url/scheme=] of the <{link/href}> attribute indicates supported paymen
   <p><code class="html">&lt;link rel="facilitated-payment" href="paypal://paypal.com?payee-address=175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W&amp;currency=USD&amp;amount=20.3&amp;payee-name=Walmart"&gt;</code></p>
 </div>
 
+> Non-Normative Note: Chromium plans to accept URLs with non-https schemes of "duitnow", "shopeepay", and "tngd" and forward them via a proprietary protocol to Google Pay. Although this protocol is not standardized, please reach out for conversations to document or standardize this protocol (e.g., via an extension API).
+
 The appropriate times to <a spec="HTML">fetch and process the linked resource</a> for such a link are:
 
 * When the [=external resource link=] is created on a <{link}> element that is already [=browsing-context connected=].


### PR DESCRIPTION
Add the note following eWallet payment link example.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/paymentlink/pull/15.html" title="Last updated on Mar 21, 2025, 8:10 PM UTC (351ee23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/paymentlink/15/ccfb514...351ee23.html" title="Last updated on Mar 21, 2025, 8:10 PM UTC (351ee23)">Diff</a>